### PR TITLE
AM_PROG_LIBTOOL is obsolete, replace it with LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,7 @@ AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_CPP
 AC_PROG_INSTALL
-AM_PROG_LIBTOOL
+LT_INIT
 
 dnl --- Required standards ---
 


### PR DESCRIPTION
This issue came up during the package review for Fedora integration.

See https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html