### PR TITLE
Port chafa to i386 architecture. (#5)

### DIFF
--- a/chafa/chafa-popcnt.c
+++ b/chafa/chafa-popcnt.c
@@ -26,7 +26,12 @@
 gint
 chafa_pop_count_u64_builtin (guint64 v)
 {
+#if !defined(CHAFA_REG_BIT32)
     return (gint) _mm_popcnt_u64 (v);
+#else
+    __int32_t* w = (__int32_t*)&v;
+    return (gint) _mm_popcnt_u32(w[0]) + _mm_popcnt_u32(w[1]);
+#endif
 }
 
 void
@@ -34,13 +39,20 @@ chafa_pop_count_vu64_builtin (const guint64 *vv, gint *vc, gint n)
 {
     while (n--)
     {
+#if !defined(CHAFA_REG_BIT32)
         *(vc++) = _mm_popcnt_u64 (*(vv++));
+#else
+         __int32_t* w = (__int32_t*)vv;
+        *(vc++) = _mm_popcnt_u32(w[0]) + _mm_popcnt_u32(w[1]);
+        vv++;
+#endif
     }
 }
 
 void
 chafa_hamming_distance_vu64_builtin (guint64 a, const guint64 *vb, gint *vc, gint n)
 {
+#if !defined(CHAFA_REG_BIT32)
     while (n >= 4)
     {
         n -= 4;
@@ -50,6 +62,15 @@ chafa_hamming_distance_vu64_builtin (guint64 a, const guint64 *vb, gint *vc, gin
         *(vc++) = _mm_popcnt_u64 (a ^ *(vb++));
     }
 
-    while (n--)
+    while (n--) {
         *(vc++) = _mm_popcnt_u64 (a ^ *(vb++));
+    }
+#else
+    __int32_t* aa = (__int32_t*)&a;
+    __int32_t* wb = (__int32_t*)vb;
+    while (n--) {
+        *(vc++) = _mm_popcnt_u32(aa[0]^wb[0]) + _mm_popcnt_u32(aa[1]^wb[1]);
+        wb += 2;
+    }
+#endif
 }

--- a/chafa/chafa-popcnt.c
+++ b/chafa/chafa-popcnt.c
@@ -26,9 +26,9 @@
 gint
 chafa_pop_count_u64_builtin (guint64 v)
 {
-#if !defined(CHAFA_REG_BIT32)
+#if defined(HAVE_POPCNT64_INTRINSICS)
     return (gint) _mm_popcnt_u64 (v);
-#else
+#else /* HAVE_POPCNT32_INTRINSICS */
     __int32_t* w = (__int32_t*)&v;
     return (gint) _mm_popcnt_u32(w[0]) + _mm_popcnt_u32(w[1]);
 #endif
@@ -39,9 +39,9 @@ chafa_pop_count_vu64_builtin (const guint64 *vv, gint *vc, gint n)
 {
     while (n--)
     {
-#if !defined(CHAFA_REG_BIT32)
+#if defined(HAVE_POPCNT64_INTRINSICS)
         *(vc++) = _mm_popcnt_u64 (*(vv++));
-#else
+#else /* HAVE_POPCNT32_INTRINSICS */
          __int32_t* w = (__int32_t*)vv;
         *(vc++) = _mm_popcnt_u32(w[0]) + _mm_popcnt_u32(w[1]);
         vv++;
@@ -52,7 +52,7 @@ chafa_pop_count_vu64_builtin (const guint64 *vv, gint *vc, gint n)
 void
 chafa_hamming_distance_vu64_builtin (guint64 a, const guint64 *vb, gint *vc, gint n)
 {
-#if !defined(CHAFA_REG_BIT32)
+#if defined(HAVE_POPCNT64_INTRINSICS)
     while (n >= 4)
     {
         n -= 4;
@@ -65,7 +65,7 @@ chafa_hamming_distance_vu64_builtin (guint64 a, const guint64 *vb, gint *vc, gin
     while (n--) {
         *(vc++) = _mm_popcnt_u64 (a ^ *(vb++));
     }
-#else
+#else /* HAVE_POPCNT32_INTRINSICS */
     __int32_t* aa = (__int32_t*)&a;
     __int32_t* wb = (__int32_t*)vb;
     while (n--) {

--- a/chafa/chafa-private.h
+++ b/chafa/chafa-private.h
@@ -198,6 +198,10 @@ void leave_mmx (void);
 gint calc_error_sse41 (const ChafaPixel *pixels, const ChafaColor *cols, const guint8 *cov) G_GNUC_PURE;
 #endif
 
+#if defined(HAVE_POPCNT64_INTRINSICS) || defined(HAVE_POPCNT32_INTRINSICS)
+#define HAVE_POPCNT_INTRINSICS
+#endif
+
 #ifdef HAVE_POPCNT_INTRINSICS
 gint chafa_pop_count_u64_builtin (guint64 v) G_GNUC_PURE;
 void chafa_pop_count_vu64_builtin (const guint64 *vv, gint *vc, gint n);

--- a/configure.ac
+++ b/configure.ac
@@ -216,7 +216,7 @@ dnl Check for working popcnt intrinsics
 AC_MSG_CHECKING(for working popcnt intrinsics)
 SAVED_CFLAGS="${CFLAGS}"
 CFLAGS="${CFLAGS} -mpopcnt"
-AC_COMPILE_IFELSE(
+AC_LINK_IFELSE(
 	[AC_LANG_PROGRAM(
 		[[#include <stdint.h>
                   #include <nmmintrin.h>]],

--- a/configure.ac
+++ b/configure.ac
@@ -212,8 +212,8 @@ CFLAGS="${SAVED_CFLAGS}"
 AC_MSG_RESULT(${ac_cv_sse41_intrinsics})
 AM_CONDITIONAL([HAVE_SSE41_INTRINSICS], [test "$ac_cv_sse41_intrinsics" = "yes"])
 
-dnl Check for working popcnt intrinsics
-AC_MSG_CHECKING(for working popcnt intrinsics)
+dnl Check for working 64bit popcnt intrinsics
+AC_MSG_CHECKING(for working 64bit popcnt intrinsics)
 SAVED_CFLAGS="${CFLAGS}"
 CFLAGS="${CFLAGS} -mpopcnt"
 AC_LINK_IFELSE(
@@ -221,12 +221,28 @@ AC_LINK_IFELSE(
 		[[#include <stdint.h>
                   #include <nmmintrin.h>]],
 		[[uint64_t t = 0; t = _mm_popcnt_u64 (t);]])],
-	[AC_DEFINE([HAVE_POPCNT_INTRINSICS], [1], [Define if popcnt intrinsics work.])
+	[AC_DEFINE([HAVE_POPCNT_INTRINSICS], [1], [Define if 64bit popcnt intrinsics work.])
 	 ac_cv_popcnt_intrinsics=yes],
 	[ac_cv_popcnt_intrinsics=no])
 CFLAGS="${SAVED_CFLAGS}"
 AC_MSG_RESULT(${ac_cv_popcnt_intrinsics})
 AM_CONDITIONAL([HAVE_POPCNT_INTRINSICS], [test "$ac_cv_popcnt_intrinsics" = "yes"])
+
+dnl Check for working 32bit popcnt intrinsics
+AC_MSG_CHECKING(for working 32bit popcnt intrinsics)
+SAVED_CFLAGS="${CFLAGS}"
+CFLAGS="${CFLAGS} -mpopcnt"
+AC_LINK_IFELSE(
+	[AC_LANG_PROGRAM(
+		[[#include <stdint.h>
+                  #include <nmmintrin.h>]],
+		[[uint32_t t = 0; t = _mm_popcnt_u32 (t);]])],
+	[AC_DEFINE([HAVE_POPCNT32_INTRINSICS], [1], [Define if 32bit popcnt intrinsics work.])
+	 ac_cv_popcnt32_intrinsics=yes],
+	[ac_cv_popcnt32_intrinsics=no])
+CFLAGS="${SAVED_CFLAGS}"
+AC_MSG_RESULT(${ac_cv_popcnt32_intrinsics})
+AM_CONDITIONAL([HAVE_POPCNT32_INTRINSICS], [test "$ac_cv_popcnt32_intrinsics" = "yes"])
 
 dnl
 dnl Check for -fvisibility=hidden to determine if we can do GNU-style

--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,6 @@ AC_LINK_IFELSE(
 	[ac_cv_popcnt64_intrinsics=no])
 CFLAGS="${SAVED_CFLAGS}"
 AC_MSG_RESULT(${ac_cv_popcnt64_intrinsics})
-AM_CONDITIONAL([HAVE_POPCNT64_INTRINSICS], [test "$ac_cv_popcnt64_intrinsics" = "yes"])
 
 dnl Check for working 32bit popcnt intrinsics
 AC_MSG_CHECKING(for working 32bit popcnt intrinsics)
@@ -242,7 +241,6 @@ AC_LINK_IFELSE(
 	[ac_cv_popcnt32_intrinsics=no])
 CFLAGS="${SAVED_CFLAGS}"
 AC_MSG_RESULT(${ac_cv_popcnt32_intrinsics})
-AM_CONDITIONAL([HAVE_POPCNT32_INTRINSICS], [test "$ac_cv_popcnt32_intrinsics" = "yes"])
 
 AM_CONDITIONAL([HAVE_POPCNT_INTRINSICS],
     [test "$ac_cv_popcnt64_intrinsics" = "yes" -o "$ac_cv_popcnt32_intrinsics" = "yes"])

--- a/configure.ac
+++ b/configure.ac
@@ -221,12 +221,12 @@ AC_LINK_IFELSE(
 		[[#include <stdint.h>
                   #include <nmmintrin.h>]],
 		[[uint64_t t = 0; t = _mm_popcnt_u64 (t);]])],
-	[AC_DEFINE([HAVE_POPCNT_INTRINSICS], [1], [Define if 64bit popcnt intrinsics work.])
-	 ac_cv_popcnt_intrinsics=yes],
-	[ac_cv_popcnt_intrinsics=no])
+	[AC_DEFINE([HAVE_POPCNT64_INTRINSICS], [1], [Define if 64bit popcnt intrinsics work.])
+	 ac_cv_popcnt64_intrinsics=yes],
+	[ac_cv_popcnt64_intrinsics=no])
 CFLAGS="${SAVED_CFLAGS}"
-AC_MSG_RESULT(${ac_cv_popcnt_intrinsics})
-AM_CONDITIONAL([HAVE_POPCNT_INTRINSICS], [test "$ac_cv_popcnt_intrinsics" = "yes"])
+AC_MSG_RESULT(${ac_cv_popcnt64_intrinsics})
+AM_CONDITIONAL([HAVE_POPCNT64_INTRINSICS], [test "$ac_cv_popcnt64_intrinsics" = "yes"])
 
 dnl Check for working 32bit popcnt intrinsics
 AC_MSG_CHECKING(for working 32bit popcnt intrinsics)
@@ -243,6 +243,9 @@ AC_LINK_IFELSE(
 CFLAGS="${SAVED_CFLAGS}"
 AC_MSG_RESULT(${ac_cv_popcnt32_intrinsics})
 AM_CONDITIONAL([HAVE_POPCNT32_INTRINSICS], [test "$ac_cv_popcnt32_intrinsics" = "yes"])
+
+AM_CONDITIONAL([HAVE_POPCNT_INTRINSICS],
+    [test "$ac_cv_popcnt64_intrinsics" = "yes" -o "$ac_cv_popcnt32_intrinsics" = "yes"])
 
 dnl
 dnl Check for -fvisibility=hidden to determine if we can do GNU-style


### PR DESCRIPTION
This avoids "_mm_popcnt_u64" symbol not found error when building chafa
on i386 architecture. However the build system is still not updated, so
one needs to specify -DCHAFA_REG_BIT32 in CFLAGS in order to build chara
on i386 architecture.

Closes: https://github.com/hpjansson/chafa/issues/5