### PR TITLE
chafa: Return TRUE (0) after print_version().

### DIFF
--- a/chafa/chafa.c
+++ b/chafa/chafa.c
@@ -685,7 +685,7 @@ parse_options (int *argc, char **argv [])
     if (options.show_version)
     {
         print_version ();
-        return FALSE;
+        return TRUE;
     }
 
     if (*argc < 2)


### PR DESCRIPTION
I need a dry-run chafa command for Debian's autopkgtest infrastructure, which continuously checks whether a package is malfunctional. However currently `chafa --help` and `chafa --version` both return FALSE (1) such that autopkgtest would consider it as an error. This is a false-positive.

Taking gcc as an example
```
$ gcc ; echo $?
gcc: fatal error: no input files
compilation terminated.
1
$ gcc --version ; echo $?
gcc (Debian 8.1.0-9) 8.1.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

0
$ gcc --help >/dev/null ; echo $?
0
$ 
```

We can see that `gcc --version` doesn't return a failure.

Similar to gcc, this patch makes `chafa --version` return `0`.