### PR TITLE
chafa-symbols: Add more symbols from "Geometric Shape" Unicode Block.

### DIFF
--- a/chafa/chafa-symbols.c
+++ b/chafa/chafa-symbols.c
@@ -1759,6 +1759,84 @@ static const ChafaSymbolDef symbol_defs [] =
         "        "
     },
     {
+        /* Black Circle */
+        CHAFA_SYMBOL_TAG_GEOMETRIC,
+        0x25cf,
+        "        "
+        "  XXXX  "
+        " XXXXXX "
+        " XXXXXX "
+        " XXXXXX "
+        "  XXXX  "
+        "        "
+        "        "
+    },
+    {
+        /* Black Lower Right Triangle */
+        CHAFA_SYMBOL_TAG_GEOMETRIC,
+        0x25e2,
+        "       X"
+        "      XX"
+        "     XXX"
+        "    XXXX"
+        "   XXXXX"
+        "  XXXXXX"
+        " XXXXXXX"
+        "XXXXXXXX"
+    },
+    {
+        /* Black Lower Left Triangle */
+        CHAFA_SYMBOL_TAG_GEOMETRIC,
+        0x25e3,
+        "X       "
+        "XX      "
+        "XXX     "
+        "XXXX    "
+        "XXXXX   "
+        "XXXXXX  "
+        "XXXXXXX "
+        "XXXXXXXX"
+    },
+    {
+        /* Black Upper Left Triangle */
+        CHAFA_SYMBOL_TAG_GEOMETRIC,
+        0x25e4,
+        "XXXXXXXX"
+        "XXXXXXX "
+        "XXXXXX  "
+        "XXXXX   "
+        "XXXX    "
+        "XXX     "
+        "XX      "
+        "X       "
+    },
+    {
+        /* Black Upper Right Triangle */
+        CHAFA_SYMBOL_TAG_GEOMETRIC,
+        0x25e5,
+        "XXXXXXXX"
+        " XXXXXXX"
+        "  XXXXXX"
+        "   XXXXX"
+        "    XXXX"
+        "     XXX"
+        "      XX"
+        "       X"
+    },
+    {
+        /* Black Medium Square */
+        CHAFA_SYMBOL_TAG_GEOMETRIC,
+        0x25fc,
+        "        "
+        "        "
+        "  XXXX  "
+        "  XXXX  "
+        "  XXXX  "
+        "  XXXX  "
+        "        "
+        "        "
+    },
+    {
         CHAFA_SYMBOL_TAG_DOT,
         0x00b7, /* Middle dot */
         "        "


### PR DESCRIPTION
I added some more triangles to the symbol table. Sometimes those triangles looks nice.

![2018-09-15_09-42](https://user-images.githubusercontent.com/5723047/45584958-fd291500-b8cb-11e8-819c-e7630ab8e4a5.png)
