### PR TITLE
docs: fix simple typo, reserach -> research

### DIFF
--- a/tools/fontgen/README.md
+++ b/tools/fontgen/README.md
@@ -26,7 +26,7 @@ The core algorithm used to generate the glyphs is
 clustering algorithms in the machine learning literature.
 
 You can generate a font by using some image dataset e.g.
-[MSCOCO](http://cocodataset.org) dataset (reserach-oriented).
+[MSCOCO](http://cocodataset.org) dataset (research-oriented).
 
 ## License
 


### PR DESCRIPTION
There is a small typo in tools/fontgen/README.md.

Should read `research` rather than `reserach`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md