### PR TITLE
Add simpleterminal (st) to 256 compatible list

### DIFF
--- a/chafa/chafa-term-db.c
+++ b/chafa/chafa-term-db.c
@@ -263,7 +263,8 @@ detect_capabilities (ChafaTermInfo *ti, gchar **envp)
      * (VTE, xterm) although some (xterm) may quantize to an indexed palette
      * regardless. */
     if (!strcmp (term, "xterm-256color")
-        || !strcmp (term, "xterm-kitty"))
+        || !strcmp (term, "xterm-kitty")
+	|| !strcmp (term, "st-256color"))
         color_seq_list = color_direct_list;
 
     /* Apple Terminal sets TERM=xterm-256color, and does not support truecolor */


### PR DESCRIPTION
st has official 256 color and true color support (https://st.suckless.org/).

This commit adds `st-256color` to the list which also contains `xterm-kitty` and `xterm-256color`