### PR TITLE
Open ended matching of foot terminfo names

### DIFF
--- a/chafa/chafa-term-db.c
+++ b/chafa/chafa-term-db.c
@@ -340,7 +340,7 @@ detect_capabilities (ChafaTermInfo *ti, gchar **envp)
         gfx_seqs = sixel_seqs;
     }
 
-    if (!strcmp(term, "foot") || !strcmp(term, "foot-direct"))
+    if (!strcmp (term, "foot") || !strncmp (term, "foot-", 5))
         gfx_seqs = sixel_seqs;
 
     /* rxvt 256-color really is 256 colors only */


### PR DESCRIPTION
Initially, foot had exactly two terminfos: `foot` and `foot-direct`.

Then, these got upstreamed to ncurses, but with certain non-standard capabilities stripped. Foot has therefore continued to ship the original terminfo files, but under different names.

These are _usually_ called `foot-extra` and `foot-extra-direct`, but the end decision is the distributions’. To handle this, match against `foot` and `foot-*`.

(as suggested in https://github.com/hpjansson/chafa/pull/59#issuecomment-905592238)