### PR TITLE
Add installation method (by scoop) on Windows

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,10 @@ OpenBSD ....... pkg_add chafa
 openSUSE ...... zypper in chafa
 Ubuntu ........ apt install chafa
 
+On Windows, Chafa can be installed by scoop:
+
+Windows ....... scoop install chafa
+
 See https://hpjansson.org/chafa/download/ for more.
 
 Installing from tarball


### PR DESCRIPTION
[Scoop](https://github.com/ScoopInstaller/Scoop) is a open source package manager on Windows.  Now scoop can install chafa from the bucket [main](https://github.com/ScoopInstaller/Main) and it uses the official windows download link in https://hpjansson.org/chafa/download/. If it is ok, could you add this installation method to the official website?