### PR TITLE
Migrate build task to GitHub Actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,78 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Running prerequisites
+      run: >
+        sudo apt install -y
+        automake
+        libtool
+        libglib2.0-dev
+        libmagickwand-dev
+        libjpeg-dev
+        librsvg2-dev
+        libtiff-dev
+        libwebp-dev
+        gtk-doc-tools
+        docbook-xml
+        libxml2-utils
+        
+        export LD_LIBRARY_PATH=$(if [[ $CC == "clang" ]]; then echo -n '/usr/local/clang/lib'; fi)
+    - name: Making without ImageMagick
+      run: >
+        mkdir build
+        
+        cd build
+        
+        CFLAGS='
+        -g 
+        -O2 
+        -fsanitize=address,undefined 
+        -fsanitize-undefined-trap-on-error 
+        -Werror -Wno-error=unused 
+        -Wno-error=unused-function 
+        -Wno-error=unused-parameter 
+        -Wno-error=unused-variable 
+        -Wno-error=unused-const-variable 
+        -Wno-error=unused-value 
+        -Wno-error=comment 
+        -Wno-error=missing-braces' 
+        ../autogen.sh --prefix=/usr --enable-gtk-doc --enable-man --without-imagemagick
+        
+        make -j4
+    - name: Making check
+      run: make check
+    - name: Making with ImageMagick
+      run: >
+        rm -Rf ../build/*
+        
+        ../autogen.sh --prefix=/usr --enable-gtk-doc --enable-man
+        
+        make -j4
+    - name: Installing chafa
+      run: >
+        sudo make install
+        
+        chafa --version
+    - name: Run post install
+      run: >
+        cd ../tests
+        
+        ./postinstall.sh
+    - name: After failure
+      if: failure()
+      run: >
+        touch tests/test-suite.log
+        
+        cat tests/test-suite.log

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -52,7 +52,7 @@ jobs:
         
         make -j4
         
-    - name: Making check
+    - name: Running tests
       working-directory: ./build
       run: make check
       

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,12 +29,12 @@ jobs:
         libxml2-utils
         
         export LD_LIBRARY_PATH=$(if [[ $CC == "clang" ]]; then echo -n '/usr/local/clang/lib'; fi)
-    - name: Making without ImageMagick
-      run: >
+        
         mkdir build
         
-        cd build
-        
+    - name: Making without ImageMagick
+      working-directory: ./build
+      run: >
         CFLAGS='
         -g 
         -O2 
@@ -51,25 +51,31 @@ jobs:
         ../autogen.sh --prefix=/usr --enable-gtk-doc --enable-man --without-imagemagick
         
         make -j4
+        
     - name: Making check
+      working-directory: ./build
       run: make check
+      
     - name: Making with ImageMagick
+      working-directory: ./build
       run: >
         rm -Rf ../build/*
-        
+
         ../autogen.sh --prefix=/usr --enable-gtk-doc --enable-man
         
         make -j4
+        
     - name: Installing chafa
+      working-directory: ./build
       run: >
         sudo make install
         
         chafa --version
-    - name: Run post install
-      run: >
-        cd ../tests
         
-        ./postinstall.sh
+    - name: Run post install
+      working-directory: ./tests
+      run: ./postinstall.sh
+      
     - name: After failure
       if: failure()
       run: >


### PR DESCRIPTION
## Summary
This pull request adds a workflow file for GitHub actions equivalent to [`.travis.yml`](https://github.com/hpjansson/chafa/blob/564376f3e991c4251c844dcdf66b3049cd85a500/.travis.yml) as per #137.

The job is split up into several steps:
1. **Running prerequisites**: Installs build requirements and executes the `LD_LIBRARY_PATH` fix
2. **Making without ImageMagick**: Executes `autogen` with the `--without-imagemagick` flag and makes chafa
3. **Running tests**: Executes `make check`
4. **Making with ImageMagick**: Executes `autogen` without the `--without-imagemagick` flag and makes chafa
5. **Installing chafa**: Runs `sudo make install` and `chafa --version`
6. **Run post install**: Runs the `postinstall.sh` script
7. **After failure**: Cats the test suite log if and only if any of the steps above fails