### PR TITLE
Fix Sixel rendering of GIF images with transparency

### DIFF
--- a/chafa/chafa-canvas.c
+++ b/chafa/chafa-canvas.c
@@ -1694,7 +1694,7 @@ chafa_canvas_print (ChafaCanvas *canvas, ChafaTermInfo *term_info)
 
         /* Sixel mode */
 
-        out = chafa_term_info_emit_begin_sixels (term_info, buf, 0, 1, 0);
+        out = chafa_term_info_emit_begin_sixels (term_info, buf, 0, 0, 0);
         *out = '\0';
         str = g_string_new (buf);
 


### PR DESCRIPTION
Fix #147 (kind of).

As suggested, I just replaced `P2=1` with `P2=0` while generating Sixel images.

However, this is rather disappointing. Not all terminals seem to support this parameter very well.

Screenshots are more descriptive than words. I configured the terminal with a background when I could.

Layout is:

```
wezterm | konsole | mlterm
--------------------------
 xterm  |  zellij |  foot
```

---

#### With `P2=1` (current)

`chafa -f sixels -d 1 poke.gif`
![p2eq1_chafa](https://github.com/hpjansson/chafa/assets/4193924/a95297e2-a18b-4576-af5f-e71395b83eed)


`cat poke.sixel`
![p2eq1_cat](https://github.com/hpjansson/chafa/assets/4193924/28f49280-c28c-4a46-91d8-44b1aceb9258)

---

#### With `P2=0` (new)

`chafa -f sixels -d 1 poke.gif`
![p2eq0_chafa](https://github.com/hpjansson/chafa/assets/4193924/cec7a475-8b21-4d71-a411-41fe10d42490)


`cat poke.sixel`
![p2eq0_cat](https://github.com/hpjansson/chafa/assets/4193924/a89a7126-67a9-4498-84b5-665eccbc2a44)

---

That looks like an improvement for `foot` but a regression for `wezterm` and `zellij`.
I think `wezterm` supports Kitty protocol, so I assume it will be preferred over Sixel most of the time?
Regarding `zellij`, rendering of GIF is already quite poor because it causes a lot of flickering (regardless of `P2` value).
Finally, for `xterm`, it fixes the layered frames but at the cost of a black background even for static images.

What are your thoughts on these results?