### PR TITLE
Fix Makefile.am for zsh completion

### DIFF
--- a/tools/completions/Makefile.am
+++ b/tools/completions/Makefile.am
@@ -3,4 +3,5 @@ EXTRA_DIST = \
 	zsh-completion.zsh
 
 .PHONY: install-zsh-completion
+install-zsh-completion:
 	install -Dm644 zsh-completion.zsh $(PREFIX)/zsh/site-functions/_chafa


### PR DESCRIPTION
`install-zsh-completion` was only added as a phony target, and running `make install-zsh-completion` does nothing.

Fixes this by declaring the target properly.