### PR TITLE
ChafaTermDb: Eat advertises color support via TERM

### DIFF
--- a/chafa/chafa-term-db.c
+++ b/chafa/chafa-term-db.c
@@ -267,6 +267,17 @@ static const SeqStr *color_16_list [] =
     NULL
 };
 
+static const SeqStr *color_8_list [] =
+{
+    color_8_seqs,
+    NULL
+};
+
+static const SeqStr *color_mono_list [] =
+{
+    NULL
+};
+
 static const SeqStr color_fbterm_seqs [] =
 {
     { CHAFA_TERM_SEQ_SET_COLOR_FG_16, "\033[1;%1}" },
@@ -550,6 +561,16 @@ detect_capabilities (ChafaTermInfo *ti, gchar **envp)
      * Eat also sets EAT_SHELL_INTEGRATION_DIR in the environment. */
     if (!strncmp (term, "eat-", 4) || strcmp (eat_shell_integration_dir, ""))
         gfx_seqs = sixel_seqs;
+    if (!strcmp (term, "eat-truecolor"))
+        color_seq_list = color_direct_list;
+    if (!strcmp (term, "eat-256color"))
+        color_seq_list = color_256_list;
+    if (!strcmp (term, "eat-16color"))
+        color_seq_list = color_16_list;
+    if (!strcmp (term, "eat-color"))
+        color_seq_list = color_8_list;
+    if (!strcmp (term, "eat-mono"))
+        color_seq_list = color_mono_list;
 
     /* 'screen' does not like truecolor at all, but 256 colors works fine.
      * Sometimes we'll see the outer terminal appended to the TERM string,

--- a/tools/chafa/chafa.c
+++ b/tools/chafa/chafa.c
@@ -1761,6 +1761,10 @@ detect_terminal (ChafaTermInfo **term_info_out, ChafaCanvasMode *mode_out,
         && chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_SET_COLOR_FG_16)
         && chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_SET_COLOR_BG_16))
         mode = CHAFA_CANVAS_MODE_INDEXED_16;
+    else if (chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_SET_COLOR_FGBG_8)
+        && chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_SET_COLOR_FG_8)
+             && chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_SET_COLOR_BG_8))
+        mode = CHAFA_CANVAS_MODE_INDEXED_8;
     else if (chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_INVERT_COLORS)
              && chafa_term_info_have_seq (term_info, CHAFA_TERM_SEQ_RESET_ATTRIBUTES))
         mode = CHAFA_CANVAS_MODE_FGBG_BGFG;


### PR DESCRIPTION
The Eat terminal advertises its color support by setting its TERM to:
* eat-truecolor when it supports more than 256 colors,
* eat-256color when it supports more than 16 colors,
* eat-16color when it supports more than 8 colors,
* eat-color when it supports more than 1 color,
* eat-mono when it supports no colors.

Note that eat-16color isn't actually supported yet, but a bug has been filed upstream: https://codeberg.org/akib/emacs-eat/issues/154