### PR TITLE
configure: fix broken bashisms resulting in logic failure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -467,7 +467,7 @@ AC_ARG_ENABLE(rpath,
               [AS_HELP_STRING([--enable-rpath],
                               [use rpath [default=no]])])
 
-AM_CONDITIONAL(ENABLE_RPATH, test "$enable_rpath" == yes)
+AM_CONDITIONAL(ENABLE_RPATH, test "$enable_rpath" = yes)
 
 dnl --- Output ---
 


### PR DESCRIPTION
Some code which was only valid using GNU bash was included. Detected in Gentoo packaging via:

```
 * QA Notice: Abnormal configure code
 *
 * ./configure: 17292: test: unexpected operator
```

Bash provides the standard `test XXX = YYY` or `[ XXX = YYY ]` utilities. It also provides the ability to spell the equals sign as a double equals. This does nothing whatsoever -- it adds no new functionality to bash, it forbids nothing, it is *literally* an exact alias.

It should never be used under any circumstances. All developers must immediately forget that it exists. Using it is non-portable and does not work in /bin/sh scripts such as configure scripts, and it results in dangerous muscle memory when used in bash scripts because it makes people unthinkingly use the double equals even in /bin/sh scripts. To add insult to injury, it makes scripts take up more disk space (by a whole byte! and sometimes even a few bytes...)

Delete this accidental bashism, and restore the ability to get correct ./configure behavior on systems where /bin/sh is something other than a symlink to GNU bash.