### PR TITLE
chafa_canvas_print_rows: term_info leak

### DIFF
--- a/chafa/chafa-canvas.c
+++ b/chafa/chafa-canvas.c
@@ -1877,6 +1877,8 @@ chafa_canvas_print_rows (ChafaCanvas *canvas, ChafaTermInfo *term_info,
         if (array_len_out)
             *array_len_out = 1;
     }
+
+    chafa_term_info_unref (term_info);
 }
 
 /**


### PR DESCRIPTION
I've noticed tons of leaks on `chafa_canvas_print_rows_strv()` according to ASAN. It appears that `chafa_canvas_print_rows()` refs term_info, but never unrefs it.