### PR TITLE
Respect `alpha_threshold = 1` in `iterm2` pixel mode

### DIFF
--- a/chafa/chafa-canvas.c
+++ b/chafa/chafa-canvas.c
@@ -1271,6 +1271,7 @@ draw_all_pixels (ChafaCanvas *canvas, ChafaPixelType src_pixel_type,
                  const guint8 *src_pixels,
                  gint src_width, gint src_height, gint src_rowstride)
 {
+    ChafaColor bg_color;
     ChafaAlign halign = CHAFA_ALIGN_START, valign = CHAFA_ALIGN_START;
     ChafaTuck tuck = CHAFA_TUCK_STRETCH;
 
@@ -1291,6 +1292,13 @@ draw_all_pixels (ChafaCanvas *canvas, ChafaPixelType src_pixel_type,
     }
 
     destroy_pixel_canvas (canvas);
+
+    if (canvas->config.pixel_mode == CHAFA_PIXEL_MODE_KITTY
+        || canvas->config.pixel_mode == CHAFA_PIXEL_MODE_ITERM2)
+    {
+        chafa_unpack_color (canvas->config.bg_color_packed_rgb, &bg_color);
+        bg_color.ch [3] = canvas->config.alpha_threshold < 1 ? 0x00 : 0xff;
+    }
 
     if (canvas->config.pixel_mode == CHAFA_PIXEL_MODE_SYMBOLS)
     {
@@ -1357,11 +1365,6 @@ draw_all_pixels (ChafaCanvas *canvas, ChafaPixelType src_pixel_type,
     }
     else if (canvas->config.pixel_mode == CHAFA_PIXEL_MODE_KITTY)
     {
-        ChafaColor bg_color;
-
-        chafa_unpack_color (canvas->config.bg_color_packed_rgb, &bg_color);
-        bg_color.ch [3] = canvas->config.alpha_threshold < 1 ? 0x00 : 0xff;
-
         /* Kitty mode */
 
         canvas->fg_palette.alpha_threshold = canvas->config.alpha_threshold;
@@ -1392,6 +1395,7 @@ draw_all_pixels (ChafaCanvas *canvas, ChafaPixelType src_pixel_type,
                                                  src_pixels,
                                                  src_width, src_height,
                                                  src_rowstride,
+                                                 bg_color,
                                                  halign, valign,
                                                  tuck);
     }

--- a/chafa/internal/chafa-iterm2-canvas.c
+++ b/chafa/internal/chafa-iterm2-canvas.c
@@ -145,10 +145,13 @@ void
 chafa_iterm2_canvas_draw_all_pixels (ChafaIterm2Canvas *iterm2_canvas, ChafaPixelType src_pixel_type,
                                      gconstpointer src_pixels,
                                      gint src_width, gint src_height, gint src_rowstride,
+                                     ChafaColor bg_color,
                                      ChafaAlign halign, ChafaAlign valign,
                                      ChafaTuck tuck)
 {
+    uint8_t bg_color_rgba [4];
     DrawCtx ctx;
+    gboolean flatten_alpha;
     gint placement_x, placement_y;
     gint placement_width, placement_height;
 
@@ -160,6 +163,10 @@ chafa_iterm2_canvas_draw_all_pixels (ChafaIterm2Canvas *iterm2_canvas, ChafaPixe
 
     if (src_width == 0 || src_height == 0)
         return;
+
+    flatten_alpha = bg_color.ch [3] == 0;
+    bg_color.ch [3] = 0xff;
+    chafa_color8_store_to_rgba8 (bg_color, bg_color_rgba);
 
     chafa_tuck_and_align (src_width, src_height,
                           iterm2_canvas->width, iterm2_canvas->height,
@@ -176,7 +183,7 @@ chafa_iterm2_canvas_draw_all_pixels (ChafaIterm2Canvas *iterm2_canvas, ChafaPixe
                                          src_height,
                                          src_rowstride,
                                          /* Fill */
-                                         NULL,
+                                         flatten_alpha ? bg_color_rgba : NULL,
                                          SMOL_PIXEL_RGBA8_UNASSOCIATED,
                                          /* Destination */
                                          NULL,

--- a/chafa/internal/chafa-iterm2-canvas.h
+++ b/chafa/internal/chafa-iterm2-canvas.h
@@ -37,6 +37,7 @@ void chafa_iterm2_canvas_destroy (ChafaIterm2Canvas *iterm2_canvas);
 void chafa_iterm2_canvas_draw_all_pixels (ChafaIterm2Canvas *iterm2_canvas, ChafaPixelType src_pixel_type,
                                           gconstpointer src_pixels,
                                           gint src_width, gint src_height, gint src_rowstride,
+                                          ChafaColor bg_color,
                                           ChafaAlign halign, ChafaAlign valign,
                                           ChafaTuck tuck);
 void chafa_iterm2_canvas_build_ansi (ChafaIterm2Canvas *iterm2_canvas, ChafaTermInfo *term_info, GString *out_str,


### PR DESCRIPTION
This makes the `iterm2` pixel mode consistent with others, especially `kitty`. Running

```
chafa images/images/c.png -f iterm -t 1
```
before and then after produced (the fire-y image in the background is my desktop background):

![Screenshot_2025-02-28_03-40-29](https://github.com/user-attachments/assets/d5aa3ad4-8e5f-455a-9991-02d27b202db8)

Fixes #254.