### PR TITLE
Respect alignment and tuck for SYMBOLS pixel mode

### DIFF
--- a/chafa/chafa-canvas.c
+++ b/chafa/chafa-canvas.c
@@ -1325,7 +1325,11 @@ draw_all_pixels (ChafaCanvas *canvas, ChafaPixelType src_pixel_type,
                                                   src_width, src_height,
                                                   src_rowstride,
                                                   canvas->pixels,
-                                                  canvas->width_pixels, canvas->height_pixels);
+                                                  canvas->width_pixels, canvas->height_pixels,
+                                                  ((gdouble) canvas->config.cell_width
+                                                   / (gdouble) canvas->config.cell_height),
+                                                  halign, valign,
+                                                  tuck);
 
             if (canvas->config.alpha_threshold == 0)
                 canvas->have_alpha = FALSE;

--- a/chafa/internal/chafa-pixops.h
+++ b/chafa/internal/chafa-pixops.h
@@ -37,7 +37,11 @@ void chafa_prepare_pixel_data_for_symbols (const ChafaPalette *palette,
                                            gint src_rowstride,
                                            ChafaPixel *dest_pixels,
                                            gint dest_width,
-                                           gint dest_height);
+                                           gint dest_height,
+                                           gdouble font_ratio,
+                                           ChafaAlign halign,
+                                           ChafaAlign valign,
+                                           ChafaTuck tuck);
 
 void chafa_sort_pixel_index_by_channel (guint8 *index,
                                         const ChafaPixel *pixels, gint n_pixels,

--- a/tools/chafa/chafa.c
+++ b/tools/chafa/chafa.c
@@ -2359,6 +2359,15 @@ parse_options (int *argc, char **argv [])
         options.scale = SCALE_MAX;
     }
 
+    /* `--exact-size on` overrides other sizing options */
+    if (options.use_exact_size == TRISTATE_TRUE)
+    {
+        options.fit_to_width = FALSE;
+        options.scale = 1.0;
+        options.stretch = FALSE;
+        using_detected_size = TRUE;
+    }
+
     if (options.invert)
     {
         guint32 temp_color;

--- a/tools/chafa/chafa.c
+++ b/tools/chafa/chafa.c
@@ -2908,7 +2908,8 @@ run_generic (const gchar *filename, gboolean is_first_file, gboolean is_first_fr
                 && dest_width == uncorrected_src_width
                 && dest_height == uncorrected_src_height)
             {
-                tuck = CHAFA_TUCK_SHRINK_TO_FIT;
+                tuck = (options.pixel_mode == CHAFA_PIXEL_MODE_SYMBOLS
+                        ? CHAFA_TUCK_FIT : CHAFA_TUCK_SHRINK_TO_FIT);
             }
 
 #if 0


### PR DESCRIPTION
Implements alignment and tuck for SYMBOLS pixel mode.

| before | after |
|--|--|
| ![Screenshot_2025-04-23_08-14-51](https://github.com/user-attachments/assets/df79e2dd-f601-42f3-b85e-e1ef01d76ecf) | ![Screenshot_2025-04-23_08-13-38](https://github.com/user-attachments/assets/754e8782-a301-49af-aa48-84d21de583a1) |

Fixes #250

## Sub-cell Scaling

This also inherently implements sub-cell scaling for SYMBOLS, as seen below (the grey white strips at the bottom and right edges respectively):

| vertical | horizontal |
|--|--|
| ![Screenshot_2025-04-23_08-35-41](https://github.com/user-attachments/assets/9a6af5a5-26a0-441e-8ec8-d897fe0f0997) | ![Screenshot_2025-04-23_08-38-13](https://github.com/user-attachments/assets/702a6907-6c31-405e-ac41-b40969c85133) |

Though, there seems to be a discrepancy between the rounding performed in `chafa_calc_canvas_geometry()` and `chafa_tuck_and_align()`, sometimes resulting in whole extra lines or columns. I'm yet to investigate, but that shouldn't be a tedious fix.

If the sub-cell scaling isn't desired in the tool, we can always use `CHAFA_TUCK_STRETCH` (in the non-grid layout) in SYMBOLS mode to retain the existing behaviour.

## A little caveat (that needs to be fixed)

This feature has a rather unfortunate side effect within the non-grid layout of the CLI tool. Currently, `--scale` has a default of 4.0 for symbols mode. Whenever `--exact-size on|auto` applies, `CHAFA_TUCK_SHRINK_TO_FIT` is used, resulting in excess lines and columns filled in with the BG color (possibly transparent) for small images, as seen below:

![Screenshot_2025-04-23_07-56-17](https://github.com/user-attachments/assets/7268223d-c7d8-44fe-8bab-5da422de9b39)

Before this PR, the image would have filled that entire grey region (like STRETCH).

I currently have two ideas:

- Always use FIT instead of SHRINK_TO_FIT in the non-grid layout, in SYMBOLS mode.
- Use a default scale of 1.0 in SYMBOLS mode.

but I'd like to hear your opinion.

Thank you. :smiley: