### PR TITLE
Grid layout intracell alignment

### DIFF
--- a/tools/chafa/chafa.c
+++ b/tools/chafa/chafa.c
@@ -3108,6 +3108,7 @@ run_grid (GList *filenames)
     grid_layout_set_grid_size (grid_layout, options.grid_width, options.grid_height);
     grid_layout_set_canvas_config (grid_layout, canvas_config);
     grid_layout_set_term_info (grid_layout, options.term_info);
+    grid_layout_set_align (grid_layout, options.horiz_align, options.vert_align);
     grid_layout_set_tuck (grid_layout,
                           options.use_exact_size == TRISTATE_TRUE
                           ? CHAFA_TUCK_SHRINK_TO_FIT

--- a/tools/chafa/chafa.c
+++ b/tools/chafa/chafa.c
@@ -1975,8 +1975,8 @@ parse_options (int *argc, char **argv [])
     options.dither_grain_height = -1;  /* Unset */
     options.dither_intensity = 1.0;
     options.animate = TRUE;
-    options.horiz_align = CHAFA_ALIGN_START;
-    options.vert_align = CHAFA_ALIGN_START;
+    options.horiz_align = CHAFA_ALIGN_MAX;  /* Unset */
+    options.vert_align = CHAFA_ALIGN_MAX;  /* Unset */
     options.probe = TRISTATE_AUTO;
     options.probe_duration = PROBE_DURATION_DEFAULT;
     options.preprocess = TRUE;
@@ -2050,6 +2050,21 @@ parse_options (int *argc, char **argv [])
     if (options.fuzz_options && *argc > 1)
     {
         fuzz_options_with_file (&options, (*argv) [1]);
+    }
+
+    /* Set default alignment depending on run mode */
+
+    if (options.horiz_align == CHAFA_ALIGN_MAX)
+    {
+        options.horiz_align = ((options.grid_width > 0 || options.grid_height > 0)
+                               ? CHAFA_ALIGN_CENTER
+                               : CHAFA_ALIGN_START);
+    }
+    if (options.vert_align == CHAFA_ALIGN_MAX)
+    {
+        options.vert_align = ((options.grid_width > 0 || options.grid_height > 0)
+                              ? CHAFA_ALIGN_END
+                              : CHAFA_ALIGN_START);
     }
 
     /* Synchronous probe for sixels, default colors, etc. */

--- a/tools/chafa/grid-layout.c
+++ b/tools/chafa/grid-layout.c
@@ -31,6 +31,8 @@ struct GridLayout
     gint n_cols, n_rows;
     ChafaCanvasConfig *canvas_config;
     ChafaTermInfo *term_info;
+    ChafaAlign halign;
+    ChafaAlign valign;
     ChafaTuck tuck;
     GList *paths, *next_path;
     gint n_items, next_item;
@@ -426,6 +428,15 @@ grid_layout_set_grid_size (GridLayout *grid, gint n_cols, gint n_rows)
     grid->n_rows = n_rows;
 
     update_geometry (grid);
+}
+
+void
+grid_layout_set_align (GridLayout *grid, ChafaAlign halign, ChafaAlign valign)
+{
+    g_return_if_fail (grid != NULL);
+
+    grid->halign = halign;
+    grid->valign = valign;
 }
 
 void

--- a/tools/chafa/grid-layout.c
+++ b/tools/chafa/grid-layout.c
@@ -102,6 +102,8 @@ build_canvas (ChafaPixelType pixel_type, const guint8 *pixels,
               gint src_width, gint src_height, gint src_rowstride,
               const ChafaCanvasConfig *config,
               gint placement_id,
+              ChafaAlign halign,
+              ChafaAlign valign,
               ChafaTuck tuck)
 {
     ChafaFrame *frame;
@@ -117,8 +119,8 @@ build_canvas (ChafaPixelType pixel_type, const guint8 *pixels,
 
     placement = chafa_placement_new (image, placement_id);
     chafa_placement_set_tuck (placement, tuck);
-    chafa_placement_set_halign (placement, CHAFA_ALIGN_CENTER);
-    chafa_placement_set_valign (placement, CHAFA_ALIGN_END);
+    chafa_placement_set_halign (placement, halign);
+    chafa_placement_set_valign (placement, valign);
     chafa_canvas_set_placement (canvas, placement);
 
     chafa_placement_unref (placement);
@@ -159,6 +161,7 @@ format_item (GridLayout *grid, const gchar *path, GString ***gsa)
     canvas = build_canvas (pixel_type, pixels,
                            src_width, src_height, src_rowstride, grid->canvas_config,
                            -1,
+                           grid->halign, grid->valign,
                            grid->tuck);
     chafa_canvas_print_rows (canvas, grid->term_info, gsa, NULL);
     success = TRUE;

--- a/tools/chafa/grid-layout.h
+++ b/tools/chafa/grid-layout.h
@@ -34,6 +34,7 @@ void grid_layout_set_canvas_config (GridLayout *grid, ChafaCanvasConfig *canvas_
 void grid_layout_set_term_info (GridLayout *grid, ChafaTermInfo *term_info);
 void grid_layout_set_view_size (GridLayout *grid, gint width, gint height);
 void grid_layout_set_grid_size (GridLayout *grid, gint n_cols, gint n_rows);
+void grid_layout_set_align (GridLayout *grid, ChafaAlign halign, ChafaAlign valign);
 void grid_layout_set_tuck (GridLayout *grid, ChafaTuck tuck);
 
 void grid_layout_push_path (GridLayout *grid, const gchar *path);


### PR DESCRIPTION
- Implements intracell alignment for the grid layout i.e `--grid` now respects `--align` within each cell.
  - Adds `halign` and `valign` fields to `GridLayout`.
  - Adds `grid_layout_set_align()`.
- Defines separate alignment defaults for grid and non-grid layouts.

| before | after |
|--|--|
| ![Screenshot_2025-04-23_08-57-02](https://github.com/user-attachments/assets/ee98839c-9631-4992-9440-275c7e824893) | ![Screenshot_2025-04-23_08-57-44](https://github.com/user-attachments/assets/6a4fa886-78bd-4325-aae6-b462e57a0bcf) |

Resolves #258, while taking https://github.com/hpjansson/chafa/issues/253#issuecomment-2689146225 into consideration.