### PR TITLE
Respect `--exact-size on` in grid layout

### DIFF
--- a/tools/chafa/chafa.c
+++ b/tools/chafa/chafa.c
@@ -3098,7 +3098,10 @@ run_grid (GList *filenames)
     grid_layout_set_grid_size (grid_layout, options.grid_width, options.grid_height);
     grid_layout_set_canvas_config (grid_layout, canvas_config);
     grid_layout_set_term_info (grid_layout, options.term_info);
-    grid_layout_set_tuck (grid_layout, options.stretch ? CHAFA_TUCK_STRETCH : CHAFA_TUCK_FIT);
+    grid_layout_set_tuck (grid_layout,
+                          options.use_exact_size == TRISTATE_TRUE
+                          ? CHAFA_TUCK_SHRINK_TO_FIT
+                          : (options.stretch ? CHAFA_TUCK_STRETCH : CHAFA_TUCK_FIT));
 
     for (l = filenames; l; l = g_list_next (l))
     {


### PR DESCRIPTION
`--grid` now respects `--exact-size on`, using `CHAFA_TUCK_SHRINK_TO_FIT`.

| before | after |
|--|--|
| ![Screenshot_2025-04-23_09-30-19](https://github.com/user-attachments/assets/f48f08f5-2dce-4643-aa18-41b1a0240c71) | ![Screenshot_2025-04-23_09-33-20](https://github.com/user-attachments/assets/b8456cb0-ef73-4f96-9525-add1bda37761) |

Works fine with large images too.

- - -

`--exact-size auto` is still left out, but it's not clear how to go about it since it'll take effect per cell.