### PR TITLE
MinGW: fix undeclared function error for strlen()

### DIFF
--- a/chafa/internal/chafa-passthrough-encoder.c
+++ b/chafa/internal/chafa-passthrough-encoder.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include <string.h>  /* strlen */
 #include "chafa.h"
 #include "internal/chafa-passthrough-encoder.h"
 


### PR DESCRIPTION
While compiling chafa with MinGW-w64, this error happened and the build process was broken:
```
/src/chafa-1.16.0/chafa/internal/chafa-passthrough-encoder.c: In function 'chafa_passthrough_encoder_append':
/src/chafa-1.16.0/chafa/internal/chafa-passthrough-encoder.c:163:54: error: implicit declaration of function 'strlen' [-Wimplicit-function-declaration]
  163 |     chafa_passthrough_encoder_append_len (ptenc, in, strlen (in));
      |                                                      ^~~~~~
/src/chafa-1.16.0/chafa/internal/chafa-passthrough-encoder.c:24:1: note: include '<string.h>' or provide a declaration of 'strlen'
   23 | #include "internal/chafa-passthrough-encoder.h"
  +++ |+#include <string.h>
   24 |
```
Attached patch fixes this error.