### PR TITLE
build: fix a typo, msudo -> sudo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,6 @@ all-local:
 	@echo --- Success! You can now run tools/chafa/chafa, or install everything
 	@echo --- using "make install" or "sudo make install".
 	@echo ---
-	@echo --- ${SETAF9}NOTE:${SGR0} You may have to run ${SETAF11}msudo ldconfig${SGR0} after installing.
+	@echo --- ${SETAF9}NOTE:${SGR0} You may have to run ${SETAF11}sudo ldconfig${SGR0} after installing.
 	@echo ---
 	@echo


### PR DESCRIPTION
The fix in #294 turned out not to be perfect.

<img width="1215" height="371" alt="image" src="https://github.com/user-attachments/assets/1d9eff36-874b-41a6-b900-1ad3ce08d6b8" />
