### PR TITLE
HeifLoader: build fix for Apple clang-17

### DIFF
--- a/tools/chafa/chicle-heif-loader.c
+++ b/tools/chafa/chicle-heif-loader.c
@@ -43,9 +43,9 @@ struct ChicleHeifLoader
     gint width, height;
     gint stride;
 
-    heif_context *ctx;
-    heif_image_handle *handle;
-    heif_image *image;
+    struct heif_context *ctx;
+    struct heif_image_handle *handle;
+    struct heif_image *image;
     const uint8_t *frame_data;
 };
 


### PR DESCRIPTION
This is small build fix for my environment.

![screenshot](https://github.com/user-attachments/assets/ba685940-d084-4920-af79-826e3368a261)

I verified builds and make check pass on macOS, Linux (debian) gcc, and MinGW-w64
