### PR TITLE
ChafaPalette: Inline palette search helpers

### DIFF
--- a/chafa/internal/chafa-palette.c
+++ b/chafa/internal/chafa-palette.c
@@ -103,7 +103,7 @@ init_candidates (ChafaColorCandidates *candidates)
     candidates->error [0] = candidates->error [1] = G_MAXINT;
 }
 
-static gboolean
+static inline gboolean
 update_candidates (ChafaColorCandidates *candidates, gint index, gint error)
 {
     if (error < candidates->error [0])
@@ -237,7 +237,7 @@ chafa_init_palette (void)
     palette_initialized = TRUE;
 }
 
-static gint
+static inline gint
 update_candidates_with_color_index_diff (ChafaColorCandidates *candidates, ChafaColorSpace color_space, const ChafaColor *color, gint index)
 {
     const ChafaColor *palette_color;


### PR DESCRIPTION
update_candidates and update_candidates_with_color_index_diff are called once per palette entry inside tight loops in pick_color_fixed_* functions. GCC does not inline them automatically at -O2, adding call/return overhead in a very hot path.

Mark both functions static inline. This is a pure compiler hint with no functional change.

**Performance**

Linux x86_64, AMD Ryzen 9 7900X, GCC 15.2 -O2, `perf stat -r 3`

| Workload | Baseline | Optimized | Delta |
|---|---|---|---|
| sixel 512x384 diffusion 256c | 1323.8 ms | 1203.9 ms | -9% |
| sixel 512x384 diffusion 16c | 1043.7 ms | 893.2 ms | -14% |